### PR TITLE
Static compile fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${OUTPUT_DIR})
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${OUTPUT_DIR})
 
 if(NOT WIN32)
-	set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC -std=c++17" )
+	set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC -std=c++17 -D_GLIBCXX_USE_CXX11_ABI=0")
 endif()
 
 set(src src/PolyTrix.cpp src/MatrixAccountSession.cpp src/PolyChatHTTPClient.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${OUTPUT_DIR})
 SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${OUTPUT_DIR})
 
 if(NOT WIN32)
-	set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC" )
+	set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fPIC -std=c++17" )
 endif()
 
 set(src src/PolyTrix.cpp src/MatrixAccountSession.cpp src/PolyChatHTTPClient.cpp)

--- a/jsoncreate.cmake
+++ b/jsoncreate.cmake
@@ -43,5 +43,5 @@ endif()
 
 file(READ "${HOME}/resources/plugin.json" json)
 STRING(REPLACE "\t\t\"!OS\": {}" "${executable_details}" json_out ${json})
-STRING(REPLACE "!PLUGIN_NAME" "polymost" json_out ${json_out})
+STRING(REPLACE "!PLUGIN_NAME" ${PROJECT_NAME} json_out ${json_out})
 file(WRITE "${OUT_DIR}/${JSON_FILE}" "${json_out}")

--- a/shared.cmake
+++ b/shared.cmake
@@ -21,7 +21,7 @@ add_custom_target(json_creation)
 add_dependencies(json_creation PolyTrix)
 add_custom_command(TARGET json_creation
 	POST_BUILD
-	COMMAND cmake -DHOME="${CMAKE_HOME_DIRECTORY}" -DEXECUTABLE="${executable_filename}" -DOUT_DIR="${OUTPUT_DIR}" -DJSON_FILE="plugin.json" -DCMAKE_SYSTEM_NAME="${CMAKE_SYSTEM_NAME}" -P ${CMAKE_HOME_DIRECTORY}/jsoncreate.cmake
+	COMMAND cmake -DHOME="${CMAKE_HOME_DIRECTORY}" -DEXECUTABLE="${executable_filename}" -DOUT_DIR="${OUTPUT_DIR}" -DJSON_FILE="plugin.json" -DCMAKE_SYSTEM_NAME="${CMAKE_SYSTEM_NAME}" -DPROJECT_NAME="polytrix" -P ${CMAKE_HOME_DIRECTORY}/jsoncreate.cmake
 ) 
 
 add_custom_target(create_zip

--- a/shared.cmake
+++ b/shared.cmake
@@ -7,6 +7,7 @@ set(json_file ${OUTPUT_DIR}/plugin.json)
 ADD_LIBRARY(PolyTrix SHARED ${src})
 
 get_target_property(DYN_INCLUDE_DIRS PolyTrix INCLUDE_DIRECTORIES)
+target_compile_definitions(PolyTrix PUBLIC -DPOLYTRIX_SHARED)
 list(APPEND DYN_INCLUDE_DIRS ${PROJECT_SOURCE_DIR})
 list(APPEND DYN_INCLUDE_DIRS ${PROJECT_BINARY_DIR})
 #if(DEFINED POLYCHAT)

--- a/src/PolyTrix.cpp
+++ b/src/PolyTrix.cpp
@@ -1,6 +1,3 @@
-#ifndef Matrix_TEST
-#define Matrix_TEST
-
 #include "PolyTrix.h"
 #include "MatrixAccountSession.h"
 
@@ -77,6 +74,7 @@ LibMatrix::HTTPClientBase* PolyTrix::httpInitializer(const std::string& basePath
 }
 
 
+#ifdef POLYTRIX_SHARED
 extern "C" {
 #ifdef _WIN32
 	__declspec(dllexport) PolyTrix* create()


### PR DESCRIPTION
Fixes static compiling and adds preprocessor definition to prevent collisions.

- Set the ABI to not use CXX11
- Set a preprocessor definition to skip past `extern "C"` functions for static builds, since they are not needed anyways