### PR TITLE
Fix missing include

### DIFF
--- a/src/PolyTrix.h
+++ b/src/PolyTrix.h
@@ -5,6 +5,9 @@
 #include <vector>
 #include <set>
 #include "libmatrix-client/include/libmatrix-client/HTTP.h"
+#include <unordered_map>
+#include <map>
+
 
 using namespace Polychat;
 


### PR DESCRIPTION
Fixes Mac OS support.

This is needed on clang but nothing else, but it is best practice to include everything you need in the individual files